### PR TITLE
feat: strip and truncate doc strings

### DIFF
--- a/click_command_tree.py
+++ b/click_command_tree.py
@@ -45,7 +45,7 @@ def _print_tree(command, depth=0, is_last_item=False, is_last_parent=False):
         tree_item = '└── ' if is_last_item else '├── '
 
     line = prefix * (depth - 1) + tree_item + command.name
-    doc = command.command.__doc__
+    doc = _get_truncated_docstring(command.command)
     if doc:
         line += ' - {}'.format(doc)
 
@@ -56,3 +56,21 @@ def _print_tree(command, depth=0, is_last_item=False, is_last_parent=False):
                     depth=(depth + 1),
                     is_last_item=(i == (len(command.children) - 1)),
                     is_last_parent=is_last_item)
+
+
+def _get_truncated_docstring(command):
+    if not command.__doc__:
+        return None
+
+    doc = command.__doc__
+    lines = doc.split("\n")
+    if not lines:
+        return None
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        return line[:80] + ' ...' if len(line) > 80 else line
+

--- a/click_command_tree.py
+++ b/click_command_tree.py
@@ -59,10 +59,11 @@ def _print_tree(command, depth=0, is_last_item=False, is_last_parent=False):
 
 
 def _get_truncated_docstring(command):
-    if not command.__doc__:
+    doc = command.__doc__
+
+    if not doc:
         return None
 
-    doc = command.__doc__
     lines = doc.split("\n")
     if not lines:
         return None
@@ -74,3 +75,4 @@ def _get_truncated_docstring(command):
 
         return line[:80] + ' ...' if len(line) > 80 else line
 
+    return None

--- a/tests.py
+++ b/tests.py
@@ -195,6 +195,26 @@ root
 
         self._assert_correct_output(root, expected_output)
 
+    def test_long_docstring(self):
+        @click.group(name='root')
+        def root():
+            pass
+
+        @root.command(name='command')
+        def command():
+            """
+            this is a really long multi line doc string this is a really long multi line doc string
+            this is a really long multi line doc string this is a really long multi line doc string
+            """
+            pass
+
+        expected_output = """
+root
+└── command - this is a really long multi line doc string this is a really long multi line doc ...
+"""[1:]
+
+        self._assert_correct_output(root, expected_output)
+
     def _assert_correct_output(self, root, expected_output):
         with captured_output() as (out, err):
             tree = _build_command_tree(root)


### PR DESCRIPTION
show the first non-empty line of the docstring, and truncate it if necessary